### PR TITLE
Added a route for serving static files.

### DIFF
--- a/src/reptile/server/http.clj
+++ b/src/reptile/server/http.clj
@@ -32,6 +32,7 @@
 (defroutes ^:private ring-routes
            (GET "/chsk" ring-req (ring-ajax-get-or-ws-handshake ring-req))
            (POST "/chsk" ring-req (ring-ajax-post ring-req))
+           (route/files "/" {:root "resources/public"})
            (route/not-found "<h1>Page not found</h1>"))
 
 (def ^:private main-ring-handler


### PR DESCRIPTION
Hi,
I managed to get reptile up and running on my home server. Though in order to make the nginx-conf much easier I ended up adding a routing rule to reptile-body to serve the static files of reptile-tongue when copied to `resources/public`. 

I'm not sure if you want this in your mainline. But at least you know I got it working now.

Oh yeah and I had great fun teaching my friends Clojure over the weekend. So thank you!